### PR TITLE
Fix time formatting in redeems dashboard

### DIFF
--- a/tlapbot/templates/dashboard.html
+++ b/tlapbot/templates/dashboard.html
@@ -22,7 +22,7 @@
         </thead>
         {% for row in queue %}
         <tbody>
-            <td>{{ row[0].replace(tzinfo=utc_timezone).astimezone().hour}}:{{row[0].replace(tzinfo=utc_timezone).astimezone().minute }}</td>
+            <td>{{ row[0].replace(tzinfo=utc_timezone).astimezone().strftime("%H:%M") }}</td>
             <td>{{ row[1] }}</td>
             <td>{{ row[2] }}</td>
         </tbody>


### PR DESCRIPTION
Before this change, a redeem made at 18:06 will show as 18:6.
After this change, the time formatting routine is used instead and time is displayed well.

As discussed in the stream chat I permit you to tlap this change and license it what you want.
I tested the formula and it works, haven't tested it in context.